### PR TITLE
Fix yara python script execution in logstash pipeline

### DIFF
--- a/lib/logstash/filters/yara.rb
+++ b/lib/logstash/filters/yara.rb
@@ -108,7 +108,9 @@ class LogStash::Filters::Yara < LogStash::Filters::Base
       scores[severity] = 0
     end
 
+    matches = []
     yara_exec_error = false
+    
     begin
       command = `#{@pyyara_py} #{@file_path} #{@path_yara_rules}`
       py_json = JSON.parse(command)

--- a/logstash-filter-yara.gemspec
+++ b/logstash-filter-yara.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-filter-yara'
-  s.version = '0.0.2'
+  s.version = '0.0.3'
   s.licenses = ['GNU AFFERO GENERAL PUBLIC LICENSE']
   s.summary = "plugin to manage yara data pipeline"
   s.description = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
The primary cause of this error is the size of the input file. Large files have a higher probability of matching many YARA rules.

The execution is now handled in a "begin rescue" but the proper fix is to review the yara rules.